### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CScan.yml
+++ b/.github/workflows/CScan.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MBarkerUK/A3PT/security/code-scanning/38](https://github.com/MBarkerUK/A3PT/security/code-scanning/38)

To fix the issue, add a `permissions` block at the root level of the workflow file. Since the workflow only performs static analysis tasks and does not require write access to the repository, the permissions can be set to `contents: read`. This ensures that the workflow has the minimum necessary permissions to operate securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
